### PR TITLE
update: board 제외 테스트 후 수정 완료

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -24,7 +24,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   private static extractJWT(req: RequestType): string | null {
-    console.log(req.headers.cookie);
     if (
       req.headers.cookie &&
       req.headers.cookie.length > 0

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -40,7 +40,7 @@ export class BoardController {
   @UseGuards(AuthGuard('jwt'))
   async updateBoard(
     @UserInfo() user: User,
-    @Param('id') id: number,
+    @Param('boardId') id: number,
     @Body() updateBoardDto: UpdateBoardDto,
   ) {
     return await this.boardService.updateBoard(user, id, updateBoardDto);

--- a/src/board/entities/board.entity.ts
+++ b/src/board/entities/board.entity.ts
@@ -33,7 +33,9 @@ export class Board {
   @CreateDateColumn()
   createdAt: Date;
 
-  @ManyToOne(() => User, (user) => user.board)
+  @ManyToOne(() => User, (user) => user.board, {
+    onDelete: 'CASCADE'
+  })
   @JoinColumn()
   user: User;
 

--- a/src/card/card.module.ts
+++ b/src/card/card.module.ts
@@ -48,7 +48,7 @@ import { ListModule } from 'src/list/list.module';
         }
       },
     }),
-  ], // List, Shared는 삭제예정
+  ],
   controllers: [CardController],
   providers: [CardService],
   exports: [CardService]

--- a/src/card/card.service.ts
+++ b/src/card/card.service.ts
@@ -75,17 +75,21 @@ export class CardService {
     return await this.cardRepository.findOneBy({ worker: newCard.worker });
   }
 
-  async findAllCards(listId: number) {
-
-
-    return `This action returns all card`;
+  // 카드 조회
+  async findListId(listId: number): Promise<Card[]> {
+    const cards = await this.cardRepository.find({ where: { listId }, order: {position: 'ASC'} });
+    if (!cards.length) {
+      throw new NotFoundException(`No cards found for list with ID ${listId}`);
+    }
+    return cards;
   }
 
   async findOneByCardId(id: number) {
-    if (_.isNil(await this.cardRepository.findOneBy({ id })))
-      throw new NotFoundException('존재하지 않는 카드입니다.')
-
-    return await this.cardRepository.findOneBy({ id });
+    const card = await this.cardRepository.findOneBy({id});
+    if (!card) {
+      throw new NotFoundException(`Card with ID ${id} not found`);
+    }
+    return card;
   }
 
   async updateCard(id: number, updateCardDto: UpdateCardDto, userId: number) {
@@ -133,7 +137,7 @@ export class CardService {
 
     // 마지막 자리로 옮기는 경우 기존 마지막녀석의 position을 그 앞으로 옮기게 값을 바꾸고
     // 이후에 우리가 선택한 녀석을 마지막자리로 보내준다(Number.MAX_VALUE/2가 마지막 수 고정)
-    else if (changePositionNumber === selectCard.length) {
+    if (changePositionNumber === selectCard.length) {
       // position을 초기화해야 하는 경우(last position과 last-1 position의 합을 2로 나눈 값이 last-1 position일 경우)
       if (selectCard[selectCard.length - 2].position === (selectPosition + selectCard[selectCard.length - 2].position) / 2) {
         const resetCard = await this.sortByPosition('card', card.listId, 'DESC');
@@ -163,14 +167,77 @@ export class CardService {
     return { message: `${changePositionNumber}번 째 순서로 변경 완료!` };
   }
 
+  async changeCardPositionToAnotherList(listId: number, cardId: number, changePositionNumber: number, userId: number) {
+    if (!listId)
+      return await this.changeCardPosition(cardId, changePositionNumber, userId);
+
+    const card = await this.findOneByCardId(cardId);
+    await this.CheckAllowBoard(card.listId, userId);
+    const changeList = await this.listService.findOne(listId);
+    
+    if (changeList.boardId !== (await this.listService.findOne(listId)).boardId)
+      throw new BadRequestException('요청하신 list는 같은 board가 아닙니다.');
+
+    const cards = await this.cardRepository.findBy({listId});
+
+    if(cards.length === 0) {
+      await this.cardRepository.update({id: cardId}, {listId, position: Number.MAX_VALUE / 2});
+      return {message: `${listId}번 리스트에 1번째 순서로 변경 완료!`};
+    }
+
+    if(changePositionNumber > cards.length)
+    throw new BadRequestException('요청한 position은 card의 범위를 넘어갔습니다.');
+
+    const selectPosition = cards[changePositionNumber - 1].position;
+
+    // 첫 번째 자리로 옮기는 경우
+    if (changePositionNumber === 1) {
+      // position을 초기화 해야 하는 경우(더이상 나누어지지않고 같은 값이 되어버릴 때)
+      if (selectPosition === selectPosition / 2) {
+        const resetCard = await this.sortByPosition('card', card.listId, 'DESC');
+        await this.resetPosition(resetCard);
+      }
+      await this.cardRepository.update({ id: cardId }, { position: selectPosition / 2, listId });
+      return { message: `${listId}번 리스트의 ${changePositionNumber}번 째 순서로 변경 완료!` }
+    }
+
+    // 마지막 자리로 옮기는 경우 기존 마지막녀석의 position을 그 앞으로 옮기게 값을 바꾸고
+    // 이후에 우리가 선택한 녀석을 마지막자리로 보내준다(Number.MAX_VALUE/2가 마지막 수 고정)
+    if (changePositionNumber === cards.length) {
+      // position을 초기화해야 하는 경우(last position과 last-1 position의 합을 2로 나눈 값이 last-1 position일 경우)
+      if (cards[cards.length - 2].position === (selectPosition + cards[cards.length - 2].position) / 2) {
+        const resetCard = await this.sortByPosition('card', card.listId, 'DESC');
+        await this.resetPosition(resetCard);
+      }
+      await this.cardRepository.update({ id: cards[cards.length - 1].id }, { position: (selectPosition + cards[cards.length - 2].position) / 2 });
+      await this.cardRepository.update({ id: cardId }, { position: Number.MAX_VALUE / 2 })
+      return { message: `${listId}번 리스트의 ${changePositionNumber}번 째 순서로 변경 완료!` }
+    }
+
+    // 다른 리스트로 카드를 옮기는 경우는 무조건 그 앞의 카드와의 합을 2로 나눠준다.
+    const nextPosition = cards[changePositionNumber-2].position;
+    const changeValue = (selectPosition + nextPosition) / 2;
+
+    // position을 초기화해야 하는 경우((A + B) / 2가 A가 될 경우)
+    if (nextPosition === changeValue) {
+      const resetCard = await this.sortByPosition('card', card.listId, 'DESC');
+      await this.resetPosition(resetCard);
+    }
+
+    await this.cardRepository.update({ id: cardId }, { position: changeValue });
+
+    return { message: `${listId}번 리스트의 ${changePositionNumber}번 째 순서로 변경 완료!` };
+
+  }
+
   async uploadFile(file: Express.Multer.File, id: number) {
     await this.cardRepository.update({ id }, { image: file['location'] });
 
     return { imageUrl: file['location'] }
   }
 
-  async removeFile(id: number) {
-    const card = await this.validate(id, 1);
+  async removeFile(id: number, userId: number) {
+    const card = await this.validate(id, userId);
     if (card.image === '')
       throw new BadRequestException('해당 카드의 image는 이미 존재하지 않습니다.');
 
@@ -223,9 +290,9 @@ export class CardService {
     }
   }
 
-  async reset() {
-    await this.resetPosition(await this.sortByPosition('card', 1, 'DESC'));
-    return await this.sortByPosition('card', 1, 'ASC');
+  async reset(listId: number) {
+    await this.resetPosition(await this.sortByPosition('card', listId, 'DESC'));
+    return await this.sortByPosition('card', listId, 'ASC');
   }
 
   // validate Board 

--- a/src/card/dto/create-card.dto.ts
+++ b/src/card/dto/create-card.dto.ts
@@ -17,9 +17,6 @@ export class CreateCardDto {
 
     backgroundColor: string;
 
-    // @ApiProperty({ type: 'string', format: 'binary', description: '파일' })
-    // image: Express.Multer.File;
-
     @IsString()
     @IsNotEmpty({ message: '시작일을 입력해주세요 ex) 2024-03-18' })
     startDate: string;

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserDto {
   @IsOptional()
@@ -6,6 +6,14 @@ export class UpdateUserDto {
   email: string;
 
   @IsOptional()
+  @IsString({ message: '유효한 이름을 입력해주세요.' })
+  name: string;
+
+  @IsOptional()
   @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
   password: string;
+
+  @IsOptional()
+  @IsString({ message: '유효한 비밀번호를 입력해주세요.' })
+  changePassword: string;
 }

--- a/src/user/entities/shared.entity.ts
+++ b/src/user/entities/shared.entity.ts
@@ -26,11 +26,15 @@ export class Shared {
   @Column({ default: 'pending' })
   status: string;
 
-  @ManyToOne(() => User, (user) => user.shared)
+  @ManyToOne(() => User, (user) => user.shared, {
+    onDelete: 'CASCADE'
+  })
   @JoinColumn()
   user: User;
 
-  @ManyToOne(() => Board, (board) => board.shared)
+  @ManyToOne(() => Board, (board) => board.shared, {
+    onDelete: 'CASCADE'
+  })
   @JoinColumn()
   board: Board;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -75,7 +75,7 @@ export class UserController {
   // 회원삭제
   @UseGuards(AuthGuard('jwt')) // 인증된 사용자만 접근 가능
   @Delete(':id')
-  async remove(@Param('id') id: number): Promise<void> {
+  async remove(@Param('id') id: number): Promise<{}> {
     return this.userService.deleteUser(id);
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -93,24 +93,29 @@ export class UserService {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    if (updateUserDto.email) {
-      user.email = updateUserDto.email;
+    if (!await compare(updateUserDto.password, user.password)) {
+      throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
     }
+    await this.userRepository.update({id}, {
+      email: updateUserDto.email, 
+      name: updateUserDto.name,
+    });
 
-    if (updateUserDto.password) {
-      user.password = await hash(updateUserDto.password, 10);
-    }
+    if(updateUserDto.changePassword)
+      await this.userRepository.update({id}, {password: await hash(updateUserDto.changePassword, 10)});
 
-    return this.userRepository.save(user);
+    return await this.userRepository.findOneBy({id});
   }
 
   // 회원정보 삭제
-  async deleteUser(id: number): Promise<void> {
+  async deleteUser(id: number): Promise<{}> {
     const user = await this.userRepository.findOneBy({ id });
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    await this.userRepository.remove(user);
+    await this.userRepository.delete({id});
+
+    return {message: '삭제 완료!'};
   }
 }


### PR DESCRIPTION
수정사항:

User

+ 사용자 정보 수정에서 유효성 검사 추가(password 일치 여부)
+ email, password, changePassword, name 을 updateDto로 받고
 name, email 그리고 changePassword를 입력했을 경우 변경 가능하도록 수정
 (changePassword를 입력하지 않았다면 기존 비밀번호 그대로)
+ 사용자 정보 삭제의 경우는 편의를 위해 본인 아이디가 아니더라도 삭제 가능하도록 유지했음.

board, user, shared entity

+ casCade 지정 안되어있어 추가

Card

+ 카드를 리스트끼리 변경하고, 순서도 변경할 수 있는 api추가
  (ex 1번 리스트에있는 카드를 3번 리스트의 4번째에 넣기)
